### PR TITLE
Allow expires at in generates_token_for to be a proc

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Allow procs in generates_token_for expires_at.
+
+    ```ruby
+    generates_token_for :thing, expires_in: -> { Current.user.timeout }
+    ```
+
+    *Jacko Zuidema*
+
 *   Support PostgreSQL `RESET` on readonly queries.
 
     ```ruby

--- a/activerecord/lib/active_record/token_for.rb
+++ b/activerecord/lib/active_record/token_for.rb
@@ -12,8 +12,12 @@ module ActiveRecord
     end
 
     TokenDefinition = Struct.new(:defining_class, :purpose, :expires_in, :block) do # :nodoc:
+      def resolved_expires_in
+        expires_in.is_a?(Proc) ? expires_in.call : expires_in
+      end
+
       def full_purpose
-        @full_purpose ||= [defining_class.name, purpose, expires_in].join("\n")
+        [defining_class.name, purpose, resolved_expires_in].join("\n")
       end
 
       def message_verifier
@@ -25,7 +29,7 @@ module ActiveRecord
       end
 
       def generate_token(model)
-        message_verifier.generate(payload_for(model), expires_in: expires_in, purpose: full_purpose)
+        message_verifier.generate(payload_for(model), expires_in: resolved_expires_in, purpose: full_purpose)
       end
 
       def resolve_token(token)

--- a/activerecord/test/cases/token_for_test.rb
+++ b/activerecord/test/cases/token_for_test.rb
@@ -11,6 +11,8 @@ class TokenForTest < ActiveRecord::TestCase
   class User < ::User
     generates_token_for :lookup
 
+    generates_token_for :dynamically_expiring_lookup, expires_in: -> { 1.minute }
+
     generates_token_for :password_reset, expires_in: 15.minutes do
       password_digest.to_s[-(31 + 22), 10] # first 10 characters of BCrypt salt
     end
@@ -26,6 +28,7 @@ class TokenForTest < ActiveRecord::TestCase
 
     @user = User.create!(password_digest: "$2a$4$#{"x" * 22}#{"y" * 31}")
     @lookup_token = @user.generate_token_for(:lookup)
+    @dynamically_expiring_lookup_token = @user.generate_token_for(:dynamically_expiring_lookup)
     @password_reset_token = @user.generate_token_for(:password_reset)
   end
 
@@ -36,6 +39,11 @@ class TokenForTest < ActiveRecord::TestCase
   test "finds record by token" do
     assert_equal @user, User.find_by_token_for(:lookup, @lookup_token)
     assert_equal @user, User.find_by_token_for!(:lookup, @lookup_token)
+  end
+
+  test "finds a record when expires in is a proc and the token has not expired" do
+    assert_equal @user, User.find_by_token_for(:dynamically_expiring_lookup, @dynamically_expiring_lookup_token)
+    assert_equal @user, User.find_by_token_for!(:dynamically_expiring_lookup, @dynamically_expiring_lookup_token)
   end
 
   test "returns nil when record is not found" do
@@ -77,6 +85,14 @@ class TokenForTest < ActiveRecord::TestCase
     assert_nil User.find_by_token_for(:password_reset, @password_reset_token)
     assert_raises(ActiveSupport::MessageVerifier::InvalidSignature) do
       User.find_by_token_for!(:password_reset, @password_reset_token)
+    end
+  end
+
+  test "does not find a record when expires in is a proc and the token has expired" do
+    travel 2.minutes
+    assert_nil User.find_by_token_for(:dynamically_expiring_lookup, @dynamically_expiring_lookup_token)
+    assert_raises(ActiveSupport::MessageVerifier::InvalidSignature) do
+      User.find_by_token_for!(:dynamically_expiring_lookup, @dynamically_expiring_lookup_token)
     end
   end
 


### PR DESCRIPTION
### Motivation / Background

The expires_in option in generates_token_for currently only accepts static duration values. Giving us no way to determine the expiration dynamically at runtime e.g., based on a per-tenant timeout.

### Detail

TokenDefinition now has a resolved_expires_in method that evaluates expires_in if it's a proc, and returns as-is otherwise. The memoization on full_purpose has been removed so that procs are resolved on each call. Both generate_token and full_purpose now use resolved_expires_in. This allows usage like:

```ruby
generates_token_for :password_reset, expires_in: -> { Current.tenant.password_reset_token_timeout }
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
